### PR TITLE
Make the dev tooling more user-friendly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ __pycache__
 # Python build/setuptools
 dist/
 *.egg-info/
+
+# Custom Python venv
+.venv/

--- a/tools/build_and_install_python_module.sh
+++ b/tools/build_and_install_python_module.sh
@@ -3,6 +3,8 @@
 set -e
 
 rm -rf dist/
-python -m build
-python -m pip uninstall --yes mdfs
-python -m pip install ./dist/mdfs-*.*.*-py3-none-*.whl
+python3 -m build
+rm -rf .venv
+python3 -m venv .venv
+source .venv/bin/activate
+python3 -m pip install ./dist/mdfs-*.*.*-py3-none-*.whl

--- a/tools/run_python_example.sh
+++ b/tools/run_python_example.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
 
-python examples/example_mdfs.py
+set -e
+
+source .venv/bin/activate
+python3 examples/example_mdfs.py


### PR DESCRIPTION
Default to python3 as python symlinks are not always in place. Use an in-repo venv.